### PR TITLE
feat: Add `moveToCoordinates` test

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 def load_module_command(model: str, slot_name: str, module_id: str):
     return {
         "data": {
@@ -91,3 +94,90 @@ def deactivate_heater_command(hs_id: str):
             },
         }
     }
+
+
+def load_labware_command(
+    deck_slot_name: str,  # TODO: Also support modules.
+    load_name: str,
+    namespace: str,
+    version: int,
+    labware_id: Optional[str] = None,
+    display_name: Optional[str] = None,
+):
+    return {
+        "data": {
+            "commandType": "loadLabware",
+            "params": {
+                "location": {"slotName": deck_slot_name},
+                "loadName": load_name,
+                "namespace": namespace,
+                "version": version,
+                "labwareId": labware_id,
+                "displayName": display_name,
+            },
+        }
+    }
+
+
+def load_pipette_command(
+    pipette_name: str,
+    mount: str,
+    pipette_id: Optional[str] = None,
+):
+    return {
+        "data": {
+            "commandType": "loadPipette",
+            "params": {
+                "pipetteName": pipette_name,
+                "mount": mount,
+                "pipetteId": pipette_id,
+            },
+        }
+    }
+
+
+def pick_up_tip_command(
+    pipette_id: str,
+    labware_id: str,
+    well_name: str,
+    # TODO: Support wellLocation also.
+):
+    return {
+        "data": {
+            "commandType": "pickUpTip",
+            "params": {
+                "pipetteId": pipette_id,
+                "labwareId": labware_id,
+                "wellName": well_name,
+            },
+        }
+    }
+
+
+def move_to_coordinates_command(
+    pipette_id: str,
+    x: float,
+    y: float,
+    z: float,
+    minimum_z_height: Optional[float] = None,
+    force_direct: Optional[bool] = None,
+):
+    body = {
+        "data": {
+            "commandType": "moveToCoordinates",
+            "params": {
+                "pipetteId": pipette_id,
+                "coordinates": {
+                    "x": x,
+                    "y": y,
+                    "z": z,
+                },
+            },
+        }
+    }
+    if minimum_z_height is not None:
+        body["data"]["params"]["minimumZHeight"] = minimum_z_height
+    if force_direct is not None:
+        body["data"]["params"]["forceDirect"] = force_direct
+
+    return body

--- a/move_to_coordinates.py
+++ b/move_to_coordinates.py
@@ -1,0 +1,132 @@
+import asyncio
+import textwrap
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.theme import Theme
+
+import commands
+from robot_client import RobotClient
+from robot_interactions import RobotInteractions
+from wizard import Wizard
+
+PIPETTE = "p20_single_gen2"
+MOUNT = "right"
+TIP_RACK = "opentrons_96_tiprack_20ul"
+TIP_RACK_SLOT = "1"
+
+# Deck coordinates of the cross in the top-left of slot 7.
+# Numbers copied from the ot2_standard.json deck definition.
+CROSS_X = 12.13
+CROSS_Y = 258.0
+CROSS_Z = 0.0
+
+# How high above the cross to put the nozzle of the pipette when there's no tip attached.
+# We can't go all the way down to the cross because the pipette can't go that low.
+# This value chosen to match the height of an opentrons_96_tiprack_20ul, for easy eyeballing.
+NO_TIP_HEIGHT = 64.69
+
+SLEEP_TIME = 1.0
+
+
+async def main(robot_ip: str, robot_port: str) -> None:
+    """Run the series of commands necessary to evaluate tip height against labware on the Heater Shaker."""  # noqa: E501
+    async with RobotClient.make(host=f"http://{robot_ip}", port=robot_port, version="*") as robot_client:
+        robot_interactions: RobotInteractions = RobotInteractions(robot_client=robot_client)
+
+        run_id = await robot_interactions.force_create_new_run()
+
+        commands_to_run = [
+            commands.load_labware_command(
+                deck_slot_name=TIP_RACK_SLOT,
+                load_name=TIP_RACK,
+                namespace="opentrons",
+                version=1,
+                labware_id="tip_rack",
+            ),
+            commands.load_pipette_command(pipette_name=PIPETTE, mount=MOUNT, pipette_id="pipette"),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X,
+                y=CROSS_Y,
+                z=CROSS_Z + NO_TIP_HEIGHT,
+            ),
+            commands.pick_up_tip_command(
+                pipette_id="pipette",
+                labware_id="tip_rack",
+                well_name="A1",
+            ),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X,
+                y=CROSS_Y,
+                z=CROSS_Z,
+            ),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X + 10,
+                y=CROSS_Y,
+                z=CROSS_Z,
+            ),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X + 20,
+                y=CROSS_Y,
+                z=CROSS_Z,
+                minimum_z_height=1,  # Lower than default, so shouldn't have any effect.
+            ),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X + 30,
+                y=CROSS_Y,
+                z=CROSS_Z,
+                minimum_z_height=130,  # Tallest Opentrons tip rack is ~100 mm.
+            ),
+            commands.move_to_coordinates_command(
+                pipette_id="pipette",
+                x=CROSS_X + 40,
+                y=CROSS_Y,
+                z=CROSS_Z,
+                force_direct=True,
+            ),
+        ]
+
+        for command in commands_to_run:
+            await robot_interactions.execute_command(run_id=run_id, req_body=command, print_timing=True)
+            await asyncio.sleep(SLEEP_TIME)
+
+
+if __name__ == "__main__":
+    custom_theme = Theme({"info": "dim cyan", "warning": "magenta", "danger": "bold red"})
+    console = Console(theme=custom_theme)
+    wizard = Wizard(console)
+    markdown_text = textwrap.dedent(
+        f"""\
+        # Live Check of Moving To Coordinates
+
+        Please load:
+
+        * A {PIPETTE} on the {MOUNT} mount.
+        * A {TIP_RACK} in slot {TIP_RACK}.
+
+        The pipette should make the following movements:
+
+        1. Move {NO_TIP_HEIGHT} mm above the cross in slot 7, without a tip.
+        2. Pick up a tip.
+        3. With a default arc height, touch the cross in slot 7.
+        4. With a default arc height again, move 1 cm right.
+        5. With higher arc height, move 1 cm right.
+        6. Without any arc (dragging across the deck), move 1 cm right.
+        """
+    )
+    console.print(
+        Panel(
+            Markdown(markdown_text),
+            style="bold magenta",
+        )
+    )
+    robot_ip = wizard.validate_ip()
+    robot_port = wizard.validate_port()
+    wizard.reset_log()
+    asyncio.run(main(robot_ip=robot_ip, robot_port=robot_port))

--- a/move_to_coordinates.py
+++ b/move_to_coordinates.py
@@ -1,3 +1,7 @@
+# TODO(mm, 2022-06-21): Port this to a fully automated G-code snapshot test
+# once we figure out how to get JSONv6 and PAPIv3 protocols running in the
+# g-code-testing project.
+
 import asyncio
 import textwrap
 

--- a/move_to_coordinates.py
+++ b/move_to_coordinates.py
@@ -85,7 +85,9 @@ async def main(robot_ip: str, robot_port: str) -> None:
                 x=CROSS_X + 30,
                 y=CROSS_Y,
                 z=CROSS_Z,
-                minimum_z_height=130,  # Tallest Opentrons tip rack is ~100 mm.
+                # Should arc a bit higher than the default.
+                # Tallest Opentrons tip rack is ~100 mm.
+                minimum_z_height=130,
             ),
             commands.move_to_coordinates_command(
                 pipette_id="pipette",


### PR DESCRIPTION
# Overview

This PR hacks together a live test for the new `moveToCoordinates` Protocol Engine command.

It loads a pipette, picks up a tip, and does a few movements around one of the deck crosses to demonstrate the different variants of `moveToCoordinates`' behavior.

# Instructions

1. Checking out this repo and set it up [per the usual instructions](https://github.com/Opentrons/otietalk/tree/582b164f123221cf242fe9ab619ab1adee5758eb#local).
2. Run `pipenv run python move_to_coordinates.py`.
3. Follow the wizard. 🧙‍♂️

# Review requests

* After seeing this work once, this really doesn't need to be a manual test. Ideally, I think we would snapshot-test this with [g-code-testing](https://github.com/Opentrons/opentrons/tree/0e29be3c5775651290a3af3471a4bf7bc8f217c3/g-code-testing). We need to figure out how to get PAPIv3 protocols and JSONv6 protocols running in that framework. Do we want to merge this PR in the meantime until that happens, or do we just want to close this PR without merging?
* Do we need any readme updates?