### PR TITLE
Improve `moveToCoordinates` test with home and drop-tip

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -154,6 +154,24 @@ def pick_up_tip_command(
     }
 
 
+def drop_tip_command(
+    pipette_id: str,
+    labware_id: str,
+    well_name: str,
+    # TODO: Add wellLocation parameter.
+):
+    return {
+        "data": {
+            "commandType": "dropTip",
+            "params": {
+                "pipetteId": pipette_id,
+                "labwareId": labware_id,
+                "wellName": well_name,
+            },
+        }
+    }
+
+
 def move_to_coordinates_command(
     pipette_id: str,
     x: float,
@@ -181,3 +199,7 @@ def move_to_coordinates_command(
         body["data"]["params"]["forceDirect"] = force_direct
 
     return body
+
+
+def home_command():  # TODO: Add axes parameter.
+    return {"data": {"commandType": "home", "params": {}}}

--- a/move_to_coordinates.py
+++ b/move_to_coordinates.py
@@ -50,6 +50,7 @@ async def main(robot_ip: str, robot_port: str) -> None:
                 labware_id="tip_rack",
             ),
             commands.load_pipette_command(pipette_name=PIPETTE, mount=MOUNT, pipette_id="pipette"),
+            commands.home_command(),
             commands.move_to_coordinates_command(
                 pipette_id="pipette",
                 x=CROSS_X,
@@ -96,6 +97,15 @@ async def main(robot_ip: str, robot_port: str) -> None:
                 z=CROSS_Z,
                 force_direct=True,
             ),
+            # This drop-tip serves two purposes:
+            # 1. It returns the tip, for convenience.
+            # 2. It tests that the robot correctly plans an arc when it moves from
+            #    a coordinate location to a well location. This specific case of
+            #    returning to the last well location before the moveToCoordinates
+            #    is especially important to test because one possible bug is that
+            #    the robot still thinks it's in the same well and moves directly instead
+            #    of moving in an arc.
+            commands.drop_tip_command(pipette_id="pipette", labware_id="tip_rack", well_name="A1"),
         ]
 
         for command in commands_to_run:

--- a/robot_interactions.py
+++ b/robot_interactions.py
@@ -100,7 +100,7 @@ class RobotInteractions:
 
         async def _get_and_log_run(run_id: str) -> None:
             response = await self.robot_client.get_run(run_id)
-            log_response(response, True)
+            await log_response(response, True)
 
         async with create_task_group() as tg:
             for run_id in random_runs:


### PR DESCRIPTION
# Overview

Some small improvements atop #1.

# Changelog

* Add a `home` command to the beginning of the `moveToCoordinates` test. On my robot software version, it looks like there's a bug (https://github.com/Opentrons/opentrons/issues/10945) where the gantry isn't homed before starting the test, which sometimes causes wrong positioning. I'm not sure what our API contract should be, but an initial `home` should always be safe, even if it is redundant, so this seems like a prudent workaround for now.
* Add a `dropTip` command at the end of the test. As described in the code, this is important for testing that the robot moves away from coordinate locations correctly.
* Fix an unrelated missing `await` statement.